### PR TITLE
Remove unused token interface function references

### DIFF
--- a/RedemptionContract.sol
+++ b/RedemptionContract.sol
@@ -2,8 +2,6 @@ pragma solidity ^0.4.9;
 
 contract Token {
   function transferFrom(address from, address to, uint256 value) returns (bool success);
-  function approve(address spender, uint256 value) returns (bool success);
-  function allowance(address owner, address spender) constant returns (uint256 remaining);
 }
 
 contract RedemptionContract {


### PR DESCRIPTION
Functions were originally included to highlight process workflow. Full-fledged instructions will be made available, meaning these references are unnecessary within the contract itself.